### PR TITLE
make gibberish non-selectable by users

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,6 +141,7 @@
             word-break: break-all;
             overflow: hidden;
             color: #333;
+            user-select: none;
         }
 
         .no span {


### PR DESCRIPTION
With selectable gibberish double clicking or click-dragging selects part of the gibberish text.
![aretestsgreenyet_selectable](https://github.com/user-attachments/assets/c00280d6-2f50-47d5-afab-d60165443e56)

With this fix nor double-clicking nor click-dragging doesn't select gibberish text and it behaves more like a background.
![aretestsgreenyet_non_selectable](https://github.com/user-attachments/assets/939a4415-d6fd-40d5-b71f-571c49b83bb1)
