### PR TITLE
Use a correct property of the master workflows

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,7 +224,7 @@ function failed_tests_url(cond) {
 FROM checks
 WHERE ${cond}
     AND check_start_time >= now() - INTERVAL ${hours} HOUR
-    AND pull_request_number = 0
+    AND head_ref = 'master'
     AND test_status != 'SKIPPED'
     AND (test_status LIKE 'F%' OR test_status LIKE 'E%') 
     AND check_status != 'success'
@@ -236,7 +236,7 @@ const failed_runs = clickhouse_playground_url + "#" + btoa(
 `SELECT check_name, report_url
 FROM checks
 WHERE check_start_time >= now() - INTERVAL ${hours} HOUR
-    AND pull_request_number = 0
+    AND head_ref = 'master'
     AND test_status != 'SKIPPED'
 GROUP BY ALL
 HAVING sum((test_status LIKE 'F%' OR test_status LIKE 'E%') AND check_status != 'success') >= 20
@@ -247,7 +247,7 @@ function test_failures_url(name) {
 `SELECT check_start_time, check_name, test_name, report_url
 FROM checks
 WHERE check_start_time >= now() - INTERVAL ${hours} HOUR
-    AND pull_request_number = 0
+    AND head_ref = 'master'
     AND test_status != 'SKIPPED'
     AND (test_status LIKE 'F%' OR test_status LIKE 'E%') 
     AND check_status != 'success'
@@ -266,7 +266,7 @@ async function load() {
                     SELECT check_name, commit_sha
                     FROM checks
                     WHERE check_start_time >= now() - INTERVAL ${hours} HOUR
-                        AND pull_request_number = 0
+                        AND head_ref = 'master'
                         AND test_status != 'SKIPPED'
                     GROUP BY ALL
                     HAVING sum((test_status LIKE 'F%' OR test_status LIKE 'E%') AND check_status != 'success') >= 20)
@@ -284,7 +284,7 @@ async function load() {
                 groupUniqArrayIf(extract(test_name, '^(?:test_)?([^/]+)'), integration AND fail) AS failed_integration_tests
             FROM checks
             WHERE check_start_time >= now() - INTERVAL ${hours} HOUR
-            AND pull_request_number = 0
+            AND head_ref = 'master'
             AND test_status != 'SKIPPED' FORMAT JSON` });
 
     function onError() {
@@ -361,7 +361,7 @@ async function load() {
             FROM checks
             WHERE 1
                 AND check_start_time >= now() - INTERVAL ${hours} HOUR
-                AND pull_request_number = 0
+                AND head_ref = 'master'
                 AND test_status != 'SKIPPED'
                 AND (test_status LIKE 'F%' OR test_status LIKE 'E%')
                 AND check_status != 'success'


### PR DESCRIPTION
`pull_request_number = 0` breaks sometimes on edge cases. Let's use 100% property of running in the master branch