### PR TITLE
Escape single quotes in test names for SQL queries

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,6 +247,10 @@ GROUP BY ALL
 HAVING sum((test_status LIKE 'F%' OR test_status LIKE 'E%') AND check_status != 'success') >= 20
 ORDER BY check_name`);
 
+function escape_sql_string(s) {
+    return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
 function test_failures_url(name) {
     return clickhouse_playground_url + "#" + btoa(
 `SELECT check_start_time, check_name, test_name, report_url
@@ -259,7 +263,7 @@ WHERE check_start_time >= now() - INTERVAL ${hours} HOUR
     AND check_name NOT LIKE 'libFuzzer%'
     AND check_name != 'ClickHouse Keeper Jepsen'
     AND check_name NOT ILIKE '%experimental%'
-    AND position(test_name, '${name}') > 0
+    AND position(test_name, '${escape_sql_string(name)}') > 0
 ORDER BY check_start_time`);
 }
 


### PR DESCRIPTION
## Problem

The page builds playground SQL query links by interpolating the failing `test_name` directly into a SQL string literal. Test names frequently contain single quotes (e.g. `'forcestop'`, `'dmesg'`, `'/var/log/kern.log'`), which break out of the string literal and produce a malformed, non-runnable query.

## Fix

Added an `escape_sql_string` helper that escapes backslashes and single quotes per ClickHouse string-literal rules, and applied it to the interpolated `test_name` in `test_failures_url`.

The other query builders only interpolate trusted constants (SQL fragments and the numeric `hours`), so they don't need escaping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)